### PR TITLE
Add binary download retries and configurable health-check timeouts

### DIFF
--- a/roles/node/defaults/main.yml
+++ b/roles/node/defaults/main.yml
@@ -20,6 +20,11 @@ node_prepare_worker_binary: ""
 node_execute_worker_binary: ""
 
 node_binary_download_private_token: "{{ gitlab_private_token | default(omit) }}"
+# Retry settings for downloading binaries and their GPG signatures from the release server.
+# They help to mitigate intermittent network/release-server failures (e.g. HTTP 504 Gateway Time-out from GitHub).
+# Number of attempts per file and the delay (in seconds) between them.
+node_binary_download_retries: 6
+node_binary_download_delay: 10
 # ID of the GPG public key used for signing the Polkadot binaries.
 node_binary_release_key_id: 9D4B2B6EB8F97156D19669A9FF0812D491B96798
 # GPG signature URL. When left empty, binary verification will not be executed.
@@ -243,6 +248,12 @@ node_parachain_database_wipe: false
 node_handler_id: ""
 # Start service after playbook execution is completed
 node_start_service: true
+
+### Health check
+# After the service is running the role polls the node's `system_health` RPC endpoint until it responds.
+# Number of attempts and the delay (in seconds) between them.
+node_health_check_retries: 120
+node_health_check_delay: 10
 
 ### File used for Ansible annotation
 # File name for prometheus node-exporter textfile collector

--- a/roles/node/tasks/001-health-check.yml
+++ b/roles/node/tasks/001-health-check.yml
@@ -32,8 +32,8 @@
         use_proxy: false
       register: _node_health_check_register
       until: _node_health_check_register.status is defined and _node_health_check_register.status == 200
-      retries: 12
-      delay: 10
+      retries: "{{ node_health_check_retries }}"
+      delay: "{{ node_health_check_delay }}"
       check_mode: false
       changed_when: false
 

--- a/roles/node/tasks/400-binary.yml
+++ b/roles/node/tasks/400-binary.yml
@@ -42,6 +42,10 @@
     headers:
       PRIVATE-TOKEN: "{{ node_binary_download_private_token }}"
   loop: "{{ _node_binaries }}"
+  register: _node_binary_download
+  until: _node_binary_download is succeeded
+  retries: "{{ node_binary_download_retries }}"
+  delay: "{{ node_binary_download_delay }}"
   check_mode: false
   changed_when: false
 
@@ -58,6 +62,10 @@
       changed_when: false
       loop: "{{ _node_binaries }}"
       when: item.signature_url != ''
+      register: _node_signature_download
+      until: _node_signature_download is succeeded
+      retries: "{{ node_binary_download_retries }}"
+      delay: "{{ node_binary_download_delay }}"
 
     - name: Binary | Import release GPG public key
       ansible.builtin.command: |


### PR DESCRIPTION
## Summary

- Make Polkadot binary downloads resilient to transient release-server failures: both the binary and its GPG signature download tasks now retry on failure, controlled by the new `node_binary_download_retries` / `node_binary_download_delay` defaults (6 attempts × 10s). This rides out intermittent errors such as GitHub `HTTP 504 Gateway Time-out`.
- Make the post-start `system_health` RPC health check configurable and more patient. It was previously hardcoded to 12 attempts (~2 min); it now reads `node_health_check_retries` / `node_health_check_delay`, defaulting to 120 attempts × 10s (~20 min), so slow-starting nodes no longer fail the play prematurely.
